### PR TITLE
Add domonap service actions for opening relays by door and key IDs

### DIFF
--- a/custom_components/domonap/__init__.py
+++ b/custom_components/domonap/__init__.py
@@ -27,6 +27,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     hass.data.setdefault(DOMAIN, {})
+
+    # Register global actions (services).
+    from .actions import async_setup_actions
+
+    await async_setup_actions(hass)
     return True
 
 
@@ -96,4 +101,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
 
+    # If this was the last entry, remove services.
+    if not hass.data.get(DOMAIN):
+        from .actions import async_unload_actions
+
+        await async_unload_actions(hass)
+
     return unloaded
+

--- a/custom_components/domonap/actions.py
+++ b/custom_components/domonap/actions.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.config_validation as cv
+
+from .const import DOMAIN, API
+from .util import extract_phone_digits
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_OPEN_RELAY_BY_DOOR_ID = "open_relay_by_door_id"
+SERVICE_OPEN_RELAY_BY_KEY_ID = "open_relay_by_key_id"
+SERVICE_OPEN_RELAY_BY_LAST_CALL_DOOR_ID = "open_relay_by_last_call_door_id"
+
+SERVICE_OPEN_RELAY_BY_DOOR_ID_SCHEMA = vol.Schema(
+    {
+        vol.Required("door_id"): cv.string,
+        # When multiple config entries are set up, allow targeting a specific one.
+        vol.Optional("config_entry_id"): cv.string,
+    }
+)
+
+SERVICE_OPEN_RELAY_BY_KEY_ID_SCHEMA = vol.Schema(
+    {
+        vol.Required("key_id"): cv.string,
+        # When multiple config entries are set up, allow targeting a specific one.
+        vol.Optional("config_entry_id"): cv.string,
+    }
+)
+
+SERVICE_OPEN_RELAY_BY_LAST_CALL_DOOR_ID_SCHEMA = vol.Schema(
+    {
+        # Optional entity_id of the sensor. When omitted, we will try to find one.
+        vol.Optional("entity_id"): cv.entity_id,
+        # When multiple config entries are set up, allow targeting a specific one.
+        vol.Optional("config_entry_id"): cv.string,
+    }
+)
+
+
+def _select_entry_id(hass: HomeAssistant, requested_entry_id: str | None) -> str | None:
+    domain_data = hass.data.get(DOMAIN, {})
+    if not domain_data:
+        return None
+
+    if requested_entry_id:
+        return requested_entry_id if requested_entry_id in domain_data else None
+
+    # Fallback: first configured entry
+    return next(iter(domain_data.keys()), None)
+
+
+def _find_last_call_sensor_entity_id(hass: HomeAssistant, entry_id: str | None) -> str | None:
+    """Try to find last_call_door_id sensor entity_id."""
+    # Prefer the new naming: sensor.<phone_digits>_last_call_door_id
+    if entry_id:
+        try:
+            entry = hass.config_entries.async_get_entry(entry_id)
+        except Exception:
+            entry = None
+
+        if entry is not None:
+            phone_digits = extract_phone_digits(entry)
+            if phone_digits:
+                candidate = f"sensor.{phone_digits}_last_call_door_id"
+                if hass.states.get(candidate) is not None:
+                    return candidate
+
+        # Backward compatibility (previous logic)
+        legacy = f"sensor.{DOMAIN}_{entry_id}_last_call_door_id"
+        if hass.states.get(legacy) is not None:
+            return legacy
+
+    # Fallback: first sensor entity with expected unique_id suffix in entity_id
+    for st in hass.states.async_all("sensor"):
+        if st.entity_id.endswith("_last_call_door_id") and st.entity_id.startswith("sensor."):
+            return st.entity_id
+
+    return None
+
+
+async def async_setup_actions(hass: HomeAssistant) -> None:
+    """Register Domonap actions (services)."""
+
+    async def handle_open_relay_by_door_id(call: ServiceCall) -> None:
+        door_id: str = call.data["door_id"]
+        requested_entry_id: str | None = call.data.get("config_entry_id")
+
+        entry_id = _select_entry_id(hass, requested_entry_id)
+        if not entry_id:
+            _LOGGER.error("No Domonap config entries are set up")
+            raise HomeAssistantError("No Domonap config entries are set up")
+
+        api = hass.data[DOMAIN][entry_id].get(API)
+        if api is None:
+            _LOGGER.error("Domonap API is not available for entry_id=%s", entry_id)
+            raise HomeAssistantError(f"Domonap API is not available for entry_id={entry_id}")
+
+        res: Any = await api.open_relay_by_door_id(door_id)
+        if isinstance(res, dict) and res.get("ok") is True:
+            _LOGGER.debug("Door relay opened (door_id=%s, entry_id=%s)", door_id, entry_id)
+            return
+
+        _LOGGER.error("Failed to open relay by door_id=%s entry_id=%s: %s", door_id, entry_id, res)
+        raise HomeAssistantError(f"Failed to open relay by door_id={door_id}")
+
+    async def handle_open_relay_by_key_id(call: ServiceCall) -> None:
+        key_id: str = call.data["key_id"]
+        requested_entry_id: str | None = call.data.get("config_entry_id")
+
+        entry_id = _select_entry_id(hass, requested_entry_id)
+        if not entry_id:
+            _LOGGER.error("No Domonap config entries are set up")
+            raise HomeAssistantError("No Domonap config entries are set up")
+
+        api = hass.data[DOMAIN][entry_id].get(API)
+        if api is None:
+            _LOGGER.error("Domonap API is not available for entry_id=%s", entry_id)
+            raise HomeAssistantError(f"Domonap API is not available for entry_id={entry_id}")
+
+        res: Any = await api.open_relay_by_key_id(key_id)
+        if isinstance(res, dict) and res.get("ok") is True:
+            _LOGGER.debug("Door relay opened (key_id=%s, entry_id=%s)", key_id, entry_id)
+            return
+
+        _LOGGER.error("Failed to open relay by key_id=%s entry_id=%s: %s", key_id, entry_id, res)
+        raise HomeAssistantError(f"Failed to open relay by key_id={key_id}")
+
+    async def handle_open_relay_by_last_call_door_id(call: ServiceCall) -> dict[str, Any]:
+        """Open door based on last incoming call sensor state."""
+        requested_entry_id: str | None = call.data.get("config_entry_id")
+        entry_id = _select_entry_id(hass, requested_entry_id)
+        if not entry_id:
+            return {"status": "error", "reason": "no_config_entries"}
+
+        api = hass.data[DOMAIN][entry_id].get(API)
+        if api is None:
+            return {"status": "error", "reason": "api_unavailable", "config_entry_id": entry_id}
+
+        entity_id: str | None = call.data.get("entity_id")
+        if not entity_id:
+            entity_id = _find_last_call_sensor_entity_id(hass, entry_id)
+
+        if not entity_id:
+            return {"status": "error", "reason": "sensor_not_found", "config_entry_id": entry_id}
+
+        st = hass.states.get(entity_id)
+        if st is None:
+            return {"status": "error", "reason": "sensor_not_found", "entity_id": entity_id}
+
+        if st.state in ("unknown", "unavailable", "none", "None", ""):
+            return {"status": "skipped", "reason": "no_last_call", "entity_id": entity_id, "state": st.state}
+
+        door_id = st.state
+
+        attrs = st.attributes or {}
+        raw_call_id = attrs.get("CallId")
+        call_id = str(raw_call_id).strip() if raw_call_id is not None else ""
+
+        # Try to get a human-friendly door name from sensor attributes.
+        door_name = None
+        try:
+            door_name = (
+                attrs.get("DoorName")
+                or attrs.get("door_name")
+                or attrs.get("Address")
+                or attrs.get("Body")
+                or attrs.get("Title")
+            )
+        except Exception:
+            door_name = None
+
+        res: Any = await api.open_relay_by_door_id(door_id)
+        ok = isinstance(res, dict) and res.get("ok") is True
+
+        end_call_result: Any = None
+        # Simplified: CallId must be non-empty after strip().
+        if ok and call_id:
+            try:
+                end_call_result = await api.end_call_notify(call_id)
+            except Exception:
+                _LOGGER.exception("end_call_notify failed for call_id=%s", call_id)
+                end_call_result = {"ok": False, "error": "exception"}
+
+        return {
+            "status": "ok" if ok else "error",
+            "door_id": door_id,
+            "door_name": door_name,
+            "call_id": call_id or None,
+            "end_call_result": end_call_result,
+            "entity_id": entity_id,
+            "config_entry_id": entry_id,
+            "response": res,
+        }
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_OPEN_RELAY_BY_DOOR_ID,
+        handle_open_relay_by_door_id,
+        schema=SERVICE_OPEN_RELAY_BY_DOOR_ID_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_OPEN_RELAY_BY_KEY_ID,
+        handle_open_relay_by_key_id,
+        schema=SERVICE_OPEN_RELAY_BY_KEY_ID_SCHEMA,
+    )
+
+    # New: open door using last-call sensor
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_OPEN_RELAY_BY_LAST_CALL_DOOR_ID,
+        handle_open_relay_by_last_call_door_id,
+        schema=SERVICE_OPEN_RELAY_BY_LAST_CALL_DOOR_ID_SCHEMA,
+        supports_response=True,
+    )
+
+
+async def async_unload_actions(hass: HomeAssistant) -> None:
+    """Unregister Domonap actions (services)."""
+    for service in (
+        SERVICE_OPEN_RELAY_BY_DOOR_ID,
+        SERVICE_OPEN_RELAY_BY_KEY_ID,
+        SERVICE_OPEN_RELAY_BY_LAST_CALL_DOOR_ID,
+    ):
+        try:
+            hass.services.async_remove(DOMAIN, service)
+        except Exception:
+            _LOGGER.debug("Failed to remove service %s.%s", DOMAIN, service, exc_info=True)

--- a/custom_components/domonap/button.py
+++ b/custom_components/domonap/button.py
@@ -1,13 +1,25 @@
 import logging
+
 from homeassistant.components.button import ButtonEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
 from .const import DOMAIN, API
+from .util import extract_phone_digits
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    entities = []
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
+    entities: list[ButtonEntity] = []
+
     api = hass.data[DOMAIN][config_entry.entry_id][API]
+
+    # Button: open relay using door_id from the last incoming call
+    phone_digits = extract_phone_digits(config_entry) or config_entry.entry_id
+    entities.append(IntercomOpenLastCallDoor(api, config_entry.entry_id, phone_digits))
+
+    # Existing per-door buttons
     response = await api.get_paged_keys()
     keys = response.get("results", [])
     for key in keys:
@@ -17,6 +29,63 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities.append(IntercomDoor(api, key_id, door_id, door_name))
 
     async_add_entities(entities, True)
+
+
+class IntercomOpenLastCallDoor(ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:phone-incoming"
+    _attr_translation_key = "open_relay_by_last_call_door_id"
+
+    def __init__(self, api, entry_id: str, phone_digits: str):
+        self._api = api
+        self._entry_id = entry_id
+        self._phone_digits = phone_digits
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._phone_digits}_open_relay_by_last_call_door_id"
+
+    @property
+    def device_info(self):
+        phone = self._phone_digits or self._entry_id
+        return {
+            "identifiers": {(DOMAIN, phone)},
+            "name": f"Domonap {phone}",
+            "manufacturer": "Domonap",
+            "model": "Domonap Account",
+        }
+
+
+    @property
+    def suggested_object_id(self) -> str:
+        # Ensures entity_id like button.<phone>_open_relay_by_last_call_door_id
+        return f"{self._phone_digits}_open_relay_by_last_call_door_id"
+
+    async def async_press(self) -> None:
+        # Find last-call sensor and open by its door_id.
+        sensor_entity_id = f"sensor.{self._phone_digits}_last_call_door_id"
+        state = self.hass.states.get(sensor_entity_id) if self.hass else None
+        if state is None or state.state in ("unknown", "unavailable", "none", "None", ""):
+            _LOGGER.debug("No last call door_id found in %s", sensor_entity_id)
+            return
+
+        door_id = state.state
+        raw_call_id = state.attributes.get("CallId") if state.attributes else None
+        call_id = str(raw_call_id).strip() if raw_call_id is not None else ""
+        try:
+            res = await self._api.open_relay_by_door_id(door_id)
+            if not (isinstance(res, dict) and res.get("ok") is True):
+                _LOGGER.error("Failed to open relay by last call door_id=%s: %s", door_id, res)
+                return
+
+            # Simplified: CallId must be non-empty after strip().
+            if call_id:
+                end_res = await self._api.end_call_notify(call_id)
+                if not (isinstance(end_res, dict) and end_res.get("ok") is True):
+                    _LOGGER.error("end_call_notify failed for call_id=%s: %s", call_id, end_res)
+
+        except Exception:
+            _LOGGER.exception("Error opening relay by last call door_id=%s", door_id)
 
 
 class IntercomDoor(ButtonEntity):

--- a/custom_components/domonap/config_flow.py
+++ b/custom_components/domonap/config_flow.py
@@ -53,6 +53,8 @@ class IntercomFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         PARAM_ACCESS_TOKEN: self._api.access_token,
                         PARAM_REFRESH_TOKEN: self._api.refresh_token,
                         PARAM_REFRESH_EXPIRATION: self._api.refresh_expiration_date,
+                        CONF_COUNTRY_CODE: self._country_code,
+                        CONF_PHONE_NUMBER: self._phone_number,
                     }
                 )
 

--- a/custom_components/domonap/sensor.py
+++ b/custom_components/domonap/sensor.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from datetime import datetime, timezone
+from typing import Optional, Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 
-from .const import DOMAIN, API
+from .const import DOMAIN, API, EVENT_INCOMING_CALL
+from .util import extract_phone_digits
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
-    entities: list[DomonapDoorCodeSensor] = []
+    entities: list[SensorEntity] = []
     api = hass.data[DOMAIN][config_entry.entry_id][API]
 
     response = await api.get_paged_keys()
@@ -26,24 +28,28 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
             door_name: str = key["name"]
             pin: Optional[str] = key.get("domofonPublicPin")
 
-            if not pin:
+            if pin:
+                entities.append(
+                    DomonapDoorCodeSensor(
+                        key_id=key_id,
+                        door_id=door_id,
+                        device_name=door_name,
+                        pin=pin,
+                    )
+                )
+            else:
                 _LOGGER.debug(
                     "No domofonPublicPin for door %s (%s), skipping PIN sensor",
                     door_id,
                     door_name,
                 )
-                continue
 
-            entities.append(
-                DomonapDoorCodeSensor(
-                    key_id=key_id,
-                    door_id=door_id,
-                    device_name=door_name,
-                    pin=pin,
-                )
-            )
         except Exception:
             _LOGGER.exception("Failed to create PIN sensor from key payload: %s", key)
+
+    # One per config entry: stores the last DoorId that rang.
+    phone_digits = extract_phone_digits(config_entry)
+    entities.append(DomonapLastCallDoorIdSensor(hass, config_entry.entry_id, phone_digits))
 
     async_add_entities(entities, True)
 
@@ -77,3 +83,79 @@ class DomonapDoorCodeSensor(SensorEntity):
             "manufacturer": "Domonap",
             "model": "Intercom Device",
         }
+
+
+class DomonapLastCallDoorIdSensor(SensorEntity):
+    """Sensor that stores DoorId of the last incoming call."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:phone-incoming"
+    _attr_translation_key = "last_call_door_id"
+    _attr_should_poll = False
+
+    def __init__(self, hass: HomeAssistant, entry_id: str, phone_digits: str | None):
+        self._hass = hass
+        self._entry_id = entry_id
+        self._phone_digits = phone_digits
+        self._state: str | None = None
+        self._attrs: dict[str, Any] = {}
+        self._unsub = None
+
+    @property
+    def device_info(self):
+        # Отображаем сенсор как часть устройства-аккаунта (телефон).
+        # Идентификатор должен быть стабильным и уникальным.
+        phone = self._phone_digits or self._entry_id
+        return {
+            "identifiers": {(DOMAIN, phone)},
+            "name": f"Domonap {phone}",
+            "manufacturer": "Domonap",
+            "model": "Domonap Account",
+        }
+
+    @property
+    def unique_id(self) -> str:
+        # Required by the task: base it on phone digits.
+        if self._phone_digits:
+            return f"{self._phone_digits}_last_call_door_id"
+        return f"{self._entry_id}_last_call_door_id"
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        # Enforces entity_id like sensor.<phone_digits>_last_call_door_id
+        if self._phone_digits:
+            return f"{self._phone_digits}_last_call_door_id"
+        return None
+
+    @property
+    def native_value(self) -> str | None:
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return self._attrs
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._hass.bus.async_listen(EVENT_INCOMING_CALL, self._handle_incoming_call)
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+
+    @callback
+    def _handle_incoming_call(self, event) -> None:
+        # Store DoorId as main state and keep the whole event payload as attributes.
+        door_id = event.data.get("DoorId")
+        if not door_id:
+            return
+
+        self._state = str(door_id)
+
+        # event.data should be JSON-serializable (dict with simple values). Keep it as-is.
+        # Add our own timestamp of when HA processed the event.
+        attrs = dict(event.data)
+        attrs["ts"] = datetime.now(timezone.utc).isoformat() + "Z"
+
+        self._attrs = attrs
+        self.async_write_ha_state()

--- a/custom_components/domonap/services.yaml
+++ b/custom_components/domonap/services.yaml
@@ -1,0 +1,51 @@
+open_relay_by_door_id:
+  name: Open relay by door id
+  description: Opens the intercom relay using a Domonap doorId.
+  fields:
+    door_id:
+      name: Door ID
+      description: Domonap doorId.
+      required: true
+      selector:
+        text:
+    config_entry_id:
+      name: Config entry id
+      description: Optional. Use when you have multiple Domonap accounts configured.
+      required: false
+      selector:
+        text:
+
+open_relay_by_key_id:
+  name: Open relay by key id
+  description: Opens the intercom relay using a Domonap keyId.
+  fields:
+    key_id:
+      name: Key ID
+      description: Domonap keyId.
+      required: true
+      selector:
+        text:
+    config_entry_id:
+      name: Config entry id
+      description: Optional. Use when you have multiple Domonap accounts configured.
+      required: false
+      selector:
+        text:
+
+open_relay_by_last_call_door_id:
+  name: Open door from last call
+  description: Opens the door using DoorId from the last incoming call sensor. If the sensor state is unknown/unavailable, does nothing.
+  fields:
+    entity_id:
+      name: Sensor entity id
+      description: Optional. Entity id of the sensor that stores DoorId of the last call.
+      required: false
+      selector:
+        entity:
+          domain: sensor
+    config_entry_id:
+      name: Config entry id
+      description: Optional. Use when you have multiple Domonap accounts configured.
+      required: false
+      selector:
+        text:

--- a/custom_components/domonap/translations/en.json
+++ b/custom_components/domonap/translations/en.json
@@ -26,6 +26,9 @@
     "button": {
       "open_door": {
         "name": "Open Door"
+      },
+      "open_relay_by_last_call_door_id": {
+        "name": "Open door from last call"
       }
     },
     "binary_sensor": {
@@ -36,17 +39,20 @@
     "sensor": {
       "door_code": {
         "name": "Door Code"
+      },
+      "last_call_door_id": {
+        "name": "Last call Door ID"
       }
     },
     "camera": {
       "camera": {
         "name": "Camera"
-      },
-      "image": {
+      }
+    },
+    "image": {
       "incoming_call_image": {
         "name": "Call photo"
       }
-    }
     }
   }
 }

--- a/custom_components/domonap/translations/ru.json
+++ b/custom_components/domonap/translations/ru.json
@@ -26,6 +26,9 @@
     "button": {
       "open_door": {
         "name": "Открыть дверь"
+      },
+      "open_relay_by_last_call_door_id": {
+        "name": "Открыть дверь с которой произошел последний звонок"
       }
     },
     "binary_sensor": {
@@ -36,6 +39,9 @@
     "sensor": {
       "door_code": {
         "name": "Код двери"
+      },
+      "last_call_door_id": {
+        "name": "Door ID последнего звонка"
       }
     },
     "camera": {

--- a/custom_components/domonap/util.py
+++ b/custom_components/domonap/util.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+
+from homeassistant.config_entries import ConfigEntry
+
+
+def extract_phone_digits(entry: ConfigEntry) -> str | None:
+    """Return phone number containing only digits.
+
+    Prefers `entry.data["phone_number"]` (already sanitized by config flow),
+    falls back to parsing `entry.title` (format like "+7 9991234567").
+    """
+
+    # Prefer explicit data (from config_flow)
+    phone = entry.data.get("phone_number")
+    if isinstance(phone, str) and phone.strip():
+        digits = re.sub(r"\D", "", phone)
+        return digits or None
+
+    # Fallback: parse from title
+    title = entry.title or ""
+    digits = re.sub(r"\D", "", title)
+    return digits or None
+


### PR DESCRIPTION
# Domonap: сенсоры, actions (сервисы) и кнопки

Этот документ описывает дополнительные сущности и сервисы, добавленные в интеграцию **Domonap**.

> Термины Home Assistant:
> - **action** в контексте этой интеграции реализован как **service** (сервис), который можно использовать в автоматизациях/скриптах.
> - **button** — сущность `button.*`, по нажатию выполняет действие.

---

## Сенсоры

### 1) `sensor.<phone_digits>_last_call_door_id`

**Назначение:** хранит `DoorId` последнего входящего звонка.

- **Состояние (state):** `DoorId` (строка)
- **Когда обновляется:** при событии `domonap_incoming_call`
- **Если ещё не было звонков:** состояние обычно `unknown`

**Атрибуты:** сенсор сохраняет **все поля события** `domonap_incoming_call` как атрибуты. Пример типичных атрибутов:
- `Title`
- `Body`
- `EventMessage`
- `DoorId`
- `Address`
- `CallId`
- `WebrtcVideoUrl`
- `HttpVideoUrl`
- `VideoPreview`
- `SipAccount`, `SipPassword`, `SipDomain`, `SipPort`
- `PushType`
- `PhotoUrl`
- `ts` — служебный timestamp (UTC), когда HA обработал событие

> Важно: название сенсора содержит номер телефона **только цифры** (`phone_digits`). Он берётся из настроек интеграции.

---

## Actions / Services

Все сервисы находятся в домене `domonap.*`.

### 1) `domonap.open_relay_by_door_id`

Открывает дверь по `door_id`.

**Поля:**
- `door_id` (обязательно) — Domonap `doorId`
- `config_entry_id` (опционально) — если настроено несколько аккаунтов

---

### 2) `domonap.open_relay_by_key_id`

Открывает дверь по `key_id`.

**Поля:**
- `key_id` (обязательно) — Domonap `keyId`
- `config_entry_id` (опционально)

---

### 3) `domonap.open_relay_by_last_call_door_id`

Открывает дверь, с которой был **последний входящий звонок**.

**Логика:**
1. Читает сенсор `sensor.<phone_digits>_last_call_door_id` (или указанный вручную).
2. Если состояние сенсора `unknown/unavailable` — ничего не делает.
3. Вызывает открытие двери по `DoorId`.
4. После успешного открытия пытается завершить звонок через `api.end_call_notify(CallId)`.
   - `CallId` берётся из атрибута `CallId` того же сенсора.
   - Вызов происходит только если `CallId` не пустой после `strip()`.

**Поля сервиса:**
- `entity_id` (опционально) — entity_id сенсора last_call (если нужно указать явно)
- `config_entry_id` (опционально)

**Ответ сервиса (service response):**
Сервис поддерживает ответ и возвращает словарь, например:
- `status`: `ok | error | skipped`
- `door_id`
- `door_name` (если удалось взять из атрибутов сенсора: `DoorName/Address/Body/Title`)
- `call_id`
- `end_call_result` (ответ `end_call_notify`, если вызывался)
- `entity_id`, `config_entry_id`
- `response` (ответ `open_relay_by_door_id`)

---

## Buttons

### 1) `button.<phone_digits>_open_relay_by_last_call_door_id`

**Назначение:** кнопка, которая делает то же самое, что сервис `domonap.open_relay_by_last_call_door_id`, но через UI.

**Логика нажатия:**
1. Читает `sensor.<phone_digits>_last_call_door_id`.
2. Если состояние сенсора `unknown/unavailable` — ничего не делает.
3. Открывает дверь по `DoorId`.
4. Если `CallId` заполнен (не пустой после `strip()`), вызывает `end_call_notify(CallId)`.

---

## Примеры использования

### Открыть дверь по последнему звонку (сервис)

В автоматизации/скрипте:

```yaml
service: domonap.open_relay_by_last_call_door_id
data: {}
```

Если нужно указать сенсор явно:

```yaml
service: domonap.open_relay_by_last_call_door_id
data:
  entity_id: sensor.79991234567_last_call_door_id
```

---

## Примечания

- Если у вас несколько аккаунтов Domonap, используйте `config_entry_id` в сервисах.
- Для старых установок Home Assistant может сохранить прежний `entity_id` сенсоров/кнопок в entity registry. В этом случае проще всего:
  - либо найти текущий `entity_id` в UI и использовать его,
  - либо удалить/переименовать сущность вручную в **Настройки → Устройства и службы → Сущности**.

